### PR TITLE
bugfix/carrousel-margin

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -296,7 +296,7 @@ video {
 }
 
 .info {
-  margin-bottom: 18px;
+  margin-bottom: 28px;
 }
 
 .info__title {
@@ -486,12 +486,11 @@ video {
   }
 
   .info {
-    margin-bottom: 18px;
     width: 100%;
     left: 0;
     right: 0;
-    margin: auto;
     text-align: center;
+    margin-bottom: 60px;
   }
 
   .info__title {


### PR DESCRIPTION
added margin between info carousel and carousel image

### Desktop view:
![image](https://user-images.githubusercontent.com/27802233/61597745-99e9cc80-abd9-11e9-9953-15d8687c7099.png)

### mobile view:
![image](https://user-images.githubusercontent.com/27802233/61597756-b71e9b00-abd9-11e9-90af-9ce705aee2f8.png)

